### PR TITLE
feat: Added support for mac_address in network interface creation

### DIFF
--- a/mfd_host/base.py
+++ b/mfd_host/base.py
@@ -368,6 +368,7 @@ class Host(ABC):
                     if interface_model.random_interface is None
                     else interface_model.random_interface,
                     all_interfaces=None if interface_model.all_interfaces is None else interface_model.all_interfaces,
+                    mac_address=None if interface_model.mac_address is None else interface_model.mac_address.lower(),
                 )
                 if info:
                     filtered_info.extend([(x, interface_model) for x in info])

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ mfd-common-libs >= 1.11.0
 mfd-devcon >= 2.0.0
 mfd-typing >= 1.23.0
 mfd-package-manager >= 3, <4
-mfd-network-adapter >= 14, <15
+mfd-network-adapter@git+https://github.com/intel/mfd-network-adapter@mac_address
 mfd-kvm >= 3.12.0, < 4
 mfd-hyperv >= 2.1.0, < 3
 mfd-esxi >= 3.2.0, < 4
-mfd-model[config] >= 0.9.0
+mfd-model[config]@git+https://github.com/intel/mfd-model@mac_address
 mfd-mount >= 1.8.0
 mfd-base-tool >= 2.7.0
 mfd-sysctl >= 1.6.0, < 2


### PR DESCRIPTION
This pull request makes a minor update to how MAC addresses are handled when filtering interface information. Specifically, it ensures that the MAC address is always converted to lowercase before being used. This helps maintain consistency and avoid potential mismatches due to case sensitivity.

* Consistently converts the `mac_address` field to lowercase in the `_get_filtered_interface_info_by_topology` function in `mfd_host/base.py`.