### PR TITLE
feat: Allow filtering interface using mac_address

### DIFF
--- a/mfd_host/base.py
+++ b/mfd_host/base.py
@@ -10,6 +10,7 @@ from typing import Optional, Union, List
 from mfd_common_libs import add_logging_level, log_levels
 from mfd_typing import OSName, PCIAddress, PCIDevice
 from mfd_typing.network_interface import InterfaceType, InterfaceInfo
+from mfd_typing.mac_address import MACAddress
 
 from .exceptions import HostConnectedOSNotSupported, NetworkInterfaceRefreshException, HostConnectionTypeNotSupported
 from .feature.stats import BaseFeatureStats, StatsFeatureType
@@ -367,6 +368,9 @@ class Host(ABC):
                     random_interface=None
                     if interface_model.random_interface is None
                     else interface_model.random_interface,
+                    mac_address=None
+                    if interface_model.mac_address is None
+                    else MACAddress(addr=interface_model.mac_address),
                     all_interfaces=None if interface_model.all_interfaces is None else interface_model.all_interfaces,
                 )
                 if info:

--- a/tests/unit/test_mfd_host/test_base.py
+++ b/tests/unit/test_mfd_host/test_base.py
@@ -8,7 +8,7 @@ import pytest
 from mfd_common_libs.exceptions import UnexpectedOSException
 from mfd_connect import RPyCConnection
 from mfd_network_adapter import NetworkInterface
-from mfd_typing import OSName, PCIAddress
+from mfd_typing import MACAddress, OSName, PCIAddress
 from mfd_typing.network_interface import LinuxInterfaceInfo, InterfaceType
 
 from mfd_model.config import HostModel, NetworkInterfaceModelBase as NetworkInterfaceModel
@@ -248,6 +248,35 @@ class TestHostCreation:
             LinuxInterfaceInfo(name="eth2"),
         ]
         filtered_info = [(LinuxInterfaceInfo(name="eth0"), model)]
+        assert (
+            host._get_filtered_interface_info_by_topology(interfaces_info=interfaces_info, ignore_instantiate=False)
+            == filtered_info
+        )
+
+    def test__get_filtered_interface_info_by_topology_with_mac_address(self, host):
+        mac_str = "aa:bb:cc:dd:ee:ff"
+        model = NetworkInterfaceModel(mac_address=mac_str, instantiate=True)
+        host.topology.network_interfaces = [model]
+        interfaces_info = [
+            LinuxInterfaceInfo(mac_address=MACAddress(mac_str)),
+            LinuxInterfaceInfo(mac_address=MACAddress("11:22:33:44:55:66")),
+            LinuxInterfaceInfo(mac_address=MACAddress("aa:bb:cc:dd:ee:00")),
+        ]
+        filtered_info = [(LinuxInterfaceInfo(mac_address=MACAddress(mac_str)), model)]
+        assert (
+            host._get_filtered_interface_info_by_topology(interfaces_info=interfaces_info, ignore_instantiate=False)
+            == filtered_info
+        )
+
+    def test__get_filtered_interface_info_by_topology_with_mac_address_none(self, host):
+        model = NetworkInterfaceModel(mac_address=None, instantiate=True)
+        host.topology.network_interfaces = [model]
+        interfaces_info = [
+            LinuxInterfaceInfo(mac_address=MACAddress("aa:bb:cc:dd:ee:ff")),
+            LinuxInterfaceInfo(mac_address=MACAddress("11:22:33:44:55:66")),
+            LinuxInterfaceInfo(mac_address=MACAddress("aa:bb:cc:dd:ee:00")),
+        ]
+        filtered_info = [(info, model) for info in interfaces_info]
         assert (
             host._get_filtered_interface_info_by_topology(interfaces_info=interfaces_info, ignore_instantiate=False)
             == filtered_info


### PR DESCRIPTION
Specifying a mac_address in topology also requires the interface getting filtered in the call to mfd-network-adapter